### PR TITLE
fix: empty paths after filtering by tags

### DIFF
--- a/openapi-filter/src/openapi_filter.py
+++ b/openapi-filter/src/openapi_filter.py
@@ -44,12 +44,12 @@ def exclude_by_tag(spec, tags):
     tags = set(tags)
 
     for path, methods in spec.get("paths", {}).items():
-        filtered[path] = {}
-
         for method, attributes in methods.items():
             if tags & set(attributes.get("tags", [])):
                 continue
             else:
+                if path not in filtered:
+                    filtered[path] = {}
                 filtered[path][method] = attributes
 
     return {**spec, "paths": filtered}


### PR DESCRIPTION
* When filtering by tags we must make sure that there will be at least one method implemented for all remaing paths.
